### PR TITLE
fix: add consistent notification messages for copy to clipboard buttons

### DIFF
--- a/src/ui/components/ChatHistory.ts
+++ b/src/ui/components/ChatHistory.ts
@@ -1,5 +1,6 @@
 import { ChatMessage } from '../../core/types';
 import { UserIcon, ChatbotIcon } from '../../constants/icons';
+import { Notice } from 'obsidian';
 
 export class ChatHistory {
     public container: HTMLElement;
@@ -183,6 +184,7 @@ export class ChatHistory {
             
             button.classList.add('copied');
             setTimeout(() => button.classList.remove('copied'), 1000);
+            new Notice('Image copied to clipboard');
         } catch (error) {
             console.error('Failed to copy image to clipboard:', error);
             // Fallback: copy as data URL
@@ -190,8 +192,10 @@ export class ChatHistory {
                 await navigator.clipboard.writeText(`data:image/jpeg;base64,${imageData}`);
                 button.classList.add('copied');
                 setTimeout(() => button.classList.remove('copied'), 1000);
+                new Notice('Image copied to clipboard');
             } catch (fallbackError) {
                 console.error('Failed to copy image data URL:', fallbackError);
+                new Notice('Failed to copy image to clipboard');
             }
         }
     }
@@ -241,6 +245,9 @@ export class ChatHistory {
         navigator.clipboard.writeText(content).then(() => {
             button.classList.add('copied');
             setTimeout(() => button.classList.remove('copied'), 1000);
+            new Notice('Copied to clipboard');
+        }).catch(() => {
+            new Notice('Failed to copy to clipboard');
         });
     }
 


### PR DESCRIPTION
This PR fixes the inconsistent copy to clipboard notification behavior reported in issue #5.

## Changes
- Add Notice import from obsidian
- Enhance copyToClipboard() method to show success/error notifications
- Enhance copyImageToClipboard() method to show success/error notifications

## Problem Fixed
Previously, only some copy to clipboard buttons showed notification messages while others only provided visual feedback through CSS classes. This created an inconsistent user experience.

Now all copy buttons consistently show notification messages, providing clear feedback to users.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)